### PR TITLE
Prevent unused evidence being passed to device detection

### DIFF
--- a/DeviceDetectionOnPremise.php
+++ b/DeviceDetectionOnPremise.php
@@ -132,8 +132,9 @@ class DeviceDetectionOnPremise extends Engine {
 
         foreach($evidence as $key => $value){
 
-            $evidenceInternal->set($key, $value);
-
+            if ($this->filterEvidenceKey($key) && is_string($value)) {
+                $evidenceInternal->set($key, $value);
+            }
         }
         
         $result = $this->engine->process($evidenceInternal);


### PR DESCRIPTION
OPTIM: Added a check to ensure the value is a string and that the key is needed by the device detection engine.
Prevents unused or invalid data being passed downstream.