### PR TITLE
config tests: run only on Linux

### DIFF
--- a/ci/run-unit-tests.ps1
+++ b/ci/run-unit-tests.ps1
@@ -14,7 +14,9 @@ $env:PHP_INI_SCAN_DIR = "$sep$PWD/$RepoName"
 
 ./php/run-unit-tests.ps1 -RepoName $RepoName
 
-# Run configuration tests
-& $RepoName/configuration-tests/testConcurrencySetting.ps1 -BaseIniFilePath $PWD/$RepoName/php.ini || $(throw "configuration tests failed")
+if ($IsLinux) {
+    # Run configuration tests
+    & $RepoName/configuration-tests/testConcurrencySetting.ps1 -BaseIniFilePath $PWD/$RepoName/php.ini || $(throw "configuration tests failed")
+}
 
 exit $LASTEXITCODE


### PR DESCRIPTION
On macOS config tests fail due to concurrency related problems.