### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -2,7 +2,7 @@
 This API complies with the `common-ci` approach.
 
 The following secrets are required:
-* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing) for downloading assets (TAC hashes file and TAC CSV data file)
+* `DEVICE_DETECTION_KEY` - [license key](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for downloading assets (TAC hashes file and TAC CSV data file)
     * Example: `V3RYL0NGR4ND0M57R1NG`
 
 The following secrets are optional:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "51degrees/fiftyone.devicedetection",
     "description": "On-premise device detection engines for PHP built for the 51Degrees Pipeline API. Parse HTTP headers locally to identify device hardware, operating systems, browsers, and crawlers.",
-    "homepage": "https://51degrees.com",
+    "homepage": "https://51degrees.com?utm_source=packagist&utm_medium=package&utm_campaign=device-detection-php-onpremise&utm_content=composer.json&utm_term=homepage",
     "authors" : [
         {
             "name": "51Degrees Engineering",

--- a/examples/onpremise/classes/ExampleUtils.php
+++ b/examples/onpremise/classes/ExampleUtils.php
@@ -89,7 +89,7 @@ class ExampleUtils
                     'https://github.com/51Degrees/device-detection-data. ' .
                     'Find out about the Enterprise data file, which ' .
                     'includes automatic updates, on our pricing page: ' .
-                    'https://51degrees.com/pricing'
+                    'https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-exampleutils.php&utm_term=data-file-age-warning'
                 );
             }
 
@@ -100,7 +100,7 @@ class ExampleUtils
                     'data file. This is used for illustration, and ' .
                     'has limited accuracy and capabilities. Find ' .
                     'out about the Enterprise data file on our ' .
-                    'pricing page: https://51degrees.com/pricing'
+                    'pricing page: https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-exampleutils.php&utm_term=lite-data-file'
                 );
             }
         }

--- a/examples/onpremise/classes/GettingStartedConsole.php
+++ b/examples/onpremise/classes/GettingStartedConsole.php
@@ -58,7 +58,7 @@ class GettingStartedConsole
      * In this example, we use the DeviceDetectionPipelineBuilder
      * and configure it in code. For more information about
      * pipelines in general see the documentation at
-     * http://51degrees.com/documentation/4.3/_concepts__configuration__builders__index.html.
+     * https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedconsole.php&utm_term=run.
      *
      * @param \fiftyone\pipeline\core\Logger $logger
      */
@@ -68,9 +68,9 @@ class GettingStartedConsole
             // We use the low memory profile as its performance is
             // sufficient for this example. See the documentation for
             // more detail on this and other configuration options:
-            // http://51degrees.com/documentation/4.3/_device_detection__features__performance_options.html
-            // http://51degrees.com/documentation/4.3/_features__automatic_datafile_updates.html
-            // http://51degrees.com/documentation/4.3/_features__usage_sharing.html
+            // https://51degrees.com/documentation/_device_detection__features__performance_options.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedconsole.php&utm_term=run
+            // https://51degrees.com/documentation/_features__automatic_datafile_updates.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedconsole.php&utm_term=run
+            // https://51degrees.com/documentation/_features__usage_sharing.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedconsole.php&utm_term=run
             'performanceProfile' => 'LowMemory',
         ]);
         $pipeline = (new PipelineBuilder())
@@ -140,7 +140,7 @@ class GettingStartedConsole
 
         // Display the results of the detection, which are called
         // device properties. See the property dictionary at
-        // https://51degrees.com/developers/property-dictionary
+        // https://51degrees.com/developers/property-dictionary?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedconsole.php&utm_term=analyseevidence
         // for details of all available properties.
         $this->outputValue('Mobile Device', $device->ismobile, $message);
         $this->outputValue('Platform Name', $device->platformname, $message);

--- a/examples/onpremise/classes/GettingStartedWeb.php
+++ b/examples/onpremise/classes/GettingStartedWeb.php
@@ -53,7 +53,7 @@ class GettingStartedWeb
         // requested. So set whatever headers are required by the browser in
         // order to return the evidence needed by the pipeline.
         // More info on this can be found at
-        // https://51degrees.com/blog/user-agent-client-hints
+        // https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-gettingstartedweb.php&utm_term=processrequest
         Utils::setResponseHeader($flowData);
 
         // First we make a JSON route that will be called from the client side

--- a/examples/onpremise/classes/MatchMetrics.php
+++ b/examples/onpremise/classes/MatchMetrics.php
@@ -60,7 +60,7 @@ class MatchMetrics
             // Set the values required in the php.ini file using the
             // FiftyOneDegreesHashEngine.required_properties option.
             // If using the full on-premise data file more properties will be
-            // present in the data file. See https://51degrees.com/pricing
+            // present in the data file. See https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-matchmetrics.php&utm_term=run
         ]);
         $pipeline = (new PipelineBuilder())
             ->add($engine)

--- a/examples/onpremise/classes/MetaDataConsole.php
+++ b/examples/onpremise/classes/MetaDataConsole.php
@@ -32,7 +32,7 @@ class MetaDataConsole
      * In this example, we use the DeviceDetectionPipelineBuilder
      * and configure it in code. For more information about
      * pipelines in general see the documentation at
-     * http://51degrees.com/documentation/4.3/_concepts__configuration__builders__index.html.
+     * https://51degrees.com/documentation/_concepts__configuration__builders__index.html?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-classes-metadataconsole.php&utm_term=run.
      *
      * @param \fiftyone\pipeline\core\Logger $logger
      */

--- a/examples/onpremise/static/page.php
+++ b/examples/onpremise/static/page.php
@@ -78,7 +78,7 @@
             from the 
             <a href="https://github.com/51Degrees/device-detection-data">device-detection-data</a>
             repository on GitHub. Find out about the Enterprise data file, which includes automatic 
-            daily updates, on our <a href="https://51degrees.com/pricing">pricing page</a>.
+            daily updates, on our <a href="https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-static-page.php&utm_term=data-file-age-warning">pricing page</a>.
         </div>
     <?php } ?>
 
@@ -193,7 +193,7 @@
                 WARNING: You are using the free 'Lite' data file. This does not include the client-side
                 evidence capabilities of the paid-for data file, so you will not see any additional
                 data below. Find out about the Enterprise data file on our
-                <a href="https://51degrees.com/pricing">pricing page</a>.
+                <a href="https://51degrees.com/pricing?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-static-page.php&utm_term=lite-data-file">pricing page</a>.
             </div>
         <?php } ?>
     </div>

--- a/examples/onpremise/userAgentClientHints-Web.php
+++ b/examples/onpremise/userAgentClientHints-Web.php
@@ -82,7 +82,7 @@ $device = $flowData->device;
 // requested. So set whatever headers are required by the browser in
 // order to return the evidence needed by the pipeline.
 // More info on this can be found at
-// https://51degrees.com/blog/user-agent-client-hints
+// https://51degrees.com/blog/user-agent-client-hints?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-useragentclienthints-web.php&utm_term=top
 Utils::setResponseHeader($flowData);
 
 // Generate the HTML

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees PHP Device Detection On-Premise
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=php-open-source "Data rewards the curious") **PHP Pipeline API**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=51degrees-php-device-detection-on-premise "Data rewards the curious") **PHP Pipeline API**
 
-[Developer Documentation](https://51degrees.com/device-detection-php/index.html?utm_source=github&utm_medium=repository&utm_content=documentation&utm_campaign=php-open-source "developer documentation")
+[Developer Documentation](https://51degrees.com/device-detection-php/index.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=51degrees-php-device-detection-on-premise "developer documentation")
 
 ## Introduction
 This project contains the on-premise version of 51Degrees Device Detection for the Pipeline API.
@@ -11,8 +11,8 @@ When using on-premise device detection engines in the PHP pipeline, the appropri
 
 ## Dependencies
 
-For runtime dependencies, see our [dependencies](http://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows 
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=dependencies) page shows 
 the PHP versions that we currently test against. The software may run fine against other versions, 
 but additional caution should be applied.
 
@@ -21,7 +21,7 @@ but additional caution should be applied.
 In order to perform device detection on-premise, you will need to use a 51Degrees data file. 
 This repository includes a free, 'lite' file in the 'device-detection-data' sub-module, which has 
 a significantly reduced set of properties. To obtain a file with a more complete set of device 
-properties see the [51Degrees website](https://51degrees.com/pricing). 
+properties see the [51Degrees website](https://51degrees.com/pricing?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=data-file). 
 If you want to use the lite file, you will need to install [GitLFS](https://git-lfs.github.com/):
 
 ```
@@ -153,7 +153,7 @@ When running under Apache MPM, only `prefork` mode is supported, since `dl()` ca
 
 #### Refresh Internal Data
 
-To reload the data file, *refreshData()* needs to be called as described in this [example](https://51degrees.com/documentation/_examples__device_detection__data_file_updates__manual.html) . Thus, unless a reload is performed in the main process and all child processes, the data will not be updated. There is not a proven solution to do so yet, so we recommend a full server restart to be performed instead.
+To reload the data file, *refreshData()* needs to be called as described in this [example](https://51degrees.com/documentation/_examples__device_detection__data_file_updates__manual.html?utm_source=github&utm_medium=readme&utm_campaign=device-detection-php-onpremise&utm_content=readme.md&utm_term=refresh-internal-data) . Thus, unless a reload is performed in the main process and all child processes, the data will not be updated. There is not a proven solution to do so yet, so we recommend a full server restart to be performed instead.
 
 ## Examples
 


### PR DESCRIPTION
Tag navigational 51degrees.com and configure.51degrees.com links with the standard UTM vocabulary so the Content Team can trace traffic to its exact source. Includes the composer.json homepage (packagist/package), replaces the old logo scheme (Logo.ashx -> /img/logo.png), normalises http/www/protocol-relative variants to https, and un-versions stale documentation paths. Adds a UTM link lint workflow. The device-detection-cxx submodule is left untouched.