### PR TITLE
fix(utm): tag the contact-us links merged from #238

### DIFF
--- a/examples/onpremise/static/page.php
+++ b/examples/onpremise/static/page.php
@@ -208,8 +208,8 @@ use fiftyone\pipeline\devicedetection\examples\onpremise\classes\ExampleUtils;
     <?php $showContactUs = ExampleUtils::getDataFileTier($flowData->pipeline->getElement('device')) === 'Lite'; ?>
     <?php if ($showContactUs) { ?>
         <?php $output('<div class="c-eg-message">'); ?>
-        <?php $output('  <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>'); ?>
-        <?php $output('  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>'); ?>
+        <?php $output('  <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-static-page.php&utm_term=paid-data-file">Contact us</a> to explore the options.</p>'); ?>
+        <?php $output('  <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-static-page.php&utm_term=paid-data-file">Contact us</a>'); ?>
         <?php $output('</div>'); ?>
     <?php } ?>
 </div>

--- a/examples/onpremise/userAgentClientHints-Web.php
+++ b/examples/onpremise/userAgentClientHints-Web.php
@@ -197,8 +197,8 @@ $showContactUs = ExampleUtils::getDataFileTier($flowData->pipeline->getElement('
 
     <?php if ($showContactUs) { ?>
     <div class="c-eg-message">
-      <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us">Contact us</a> to explore the options.</p>
-      <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us">Contact us</a>
+      <p class="c-eg-message__text">The paid data file adds daily automatic updates, non-human identification and IP intelligence. <a href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-useragentclienthints-web.php&utm_term=paid-data-file">Contact us</a> to explore the options.</p>
+      <a class="b-btn c-eg-message__cta" href="https://51degrees.com/contact-us?utm_source=code&utm_medium=example&utm_campaign=device-detection-php-onpremise&utm_content=examples-onpremise-useragentclienthints-web.php&utm_term=paid-data-file">Contact us</a>
     </div>
     <?php } ?>
 </div>


### PR DESCRIPTION
Follow-up to #238. The free-tier contact-us banner links merged just before the UTM tags were applied, so `main` currently carries untagged 51degrees.com navigational links and fails the utm-link-lint check. This adds the standard five UTM parameters (source/medium/campaign/content/term) to each contact-us link. No other changes.