### PR TITLE
Fix PHP 8.4 deprecation in refreshData()

### DIFF
--- a/src/DeviceDetectionOnPremise.php
+++ b/src/DeviceDetectionOnPremise.php
@@ -149,7 +149,7 @@ class DeviceDetectionOnPremise extends Engine
      * @param null|string $fileName_or_data Data file path or the variable holding the in-memory data file
      * @param null|int $length Length of the in-memory data file in bytes
      */
-    public function refreshData(string $fileName_or_data = null, int $length = null): void
+    public function refreshData(?string $fileName_or_data = null, ?int $length = null): void
     {
         switch (func_num_args()) {
             case 0: $this->engine->refreshData();


### PR DESCRIPTION
## Summary

On PHP 8.4, `DeviceDetectionOnPremise::refreshData()` emits deprecation notices because its typed parameters have a `null` default without the explicit `?` nullable marker:

```php
public function refreshData(string $fileName_or_data = null, int $length = null): void
```

Implicitly nullable parameters are deprecated in PHP 8.4 and become a fatal error in PHP 9.0.

## Change

```php
public function refreshData(?string $fileName_or_data = null, ?int $length = null): void
```

Explicit nullable types are valid from PHP 7.1, so this is compatible with all supported versions. It is the only occurrence in `src`.

## Verified

Confirmed on PHP 8.4 that the original signature emits the deprecation for both parameters and the explicit nullable signature emits none.

Closes #242
